### PR TITLE
Don't generate service workers scripts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,14 +20,14 @@ Encore
     // .enableVersioning()
 
     // Workbox should always be the last plugin to add @see: https://developers.google.com/web/tools/workbox/guides/codelabs/webpack#optional-config
-    .addPlugin(
+    /* .addPlugin(
         new WorkboxPlugin.GenerateSW({
             // these options encourage the ServiceWorkers to get in there fast
             // and not allow any straggling "old" SWs to hang around
             clientsClaim: true,
             skipWaiting: false,
             importsDirectory: 'sw/',
-    }))
+    })) */
 ;
 // export the final configuration
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,14 +20,14 @@ Encore
     // .enableVersioning()
 
     // Workbox should always be the last plugin to add @see: https://developers.google.com/web/tools/workbox/guides/codelabs/webpack#optional-config
-    /* .addPlugin(
-        new WorkboxPlugin.GenerateSW({
-            // these options encourage the ServiceWorkers to get in there fast
-            // and not allow any straggling "old" SWs to hang around
-            clientsClaim: true,
-            skipWaiting: false,
-            importsDirectory: 'sw/',
-    })) */
+    // .addPlugin(
+    //    new WorkboxPlugin.GenerateSW({
+    //        // these options encourage the ServiceWorkers to get in there fast
+    //        // and not allow any straggling "old" SWs to hang around
+    //        clientsClaim: true,
+    //        skipWaiting: false,
+    //        importsDirectory: 'sw/',
+    // })) 
 ;
 // export the final configuration
 


### PR DESCRIPTION
@bobdenotter I just commented out the code that generates the Service Workers files and directories. If you want to get totally rid of Service Workers I can also remove files and packages used for this purpose.